### PR TITLE
Remove 'silverstripe-' from package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "firesphere/silverstripe-newsmodule",
+	"name": "firesphere/newsmodule",
 	"description": "A ModelAdmin based newsmodule to prevent clutter in the SiteTree",
 	"type": "silverstripe-module",
 	"keywords": ["silverstripe", "news", "blog", "slideshow"],


### PR DESCRIPTION
Otherwise it will check out into the 'silverstripe-newsmodule' directory on installation.

The fact that type = silverstripe-module will mean that it will still be picked up by http://extensions.andrewshort.name/ and eventually http://extensions.silverstripe.org/
