### PR TITLE
Correction name required "colymba/GridField-Bulk-Editing-Tools"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"silverstripe/framework": "3.1.*",
 		"silverstripe/cms": "3.1.*",
 		"composer/installers": "*",
-		"colymba/GridFieldBulkEditingTools" : "1.*",
+		"colymba/GridField-Bulk-Editing-Tools" : "1.*",
 		"UndefinedOffset/SortableGridField" : "*"
 	},
 	"suggest": {


### PR DESCRIPTION
I tried to install through composer, but received the following error:

  Problem 1
    - Installation request for firesphere/silverstripe-newsmodule dev-Development -> satisfiable by firesphere/silverstripe-newsmodule[dev-Development].
    - firesphere/silverstripe-newsmodule dev-Development requires colymba/gridfieldbulkeditingtools 1.\* -> no matching package found.

I think the correct package name is: "colymba/GridField-Bulk-Editing-Tools".

I'm new to Composer / Packagist so I could be completely wrong!

Marijn.
