### PR TITLE
Fatal error: Call to undefined function LiteralField() in silverstripe-n...

### DIFF
--- a/code/objects/News.php
+++ b/code/objects/News.php
@@ -211,7 +211,7 @@ class News extends DataObject { // implements IOGObject{ // optional for OpenGra
 			$translate->setMultiple(true);
 		}
 		else {
-			$translate = LiteralField('NoMultiple', '');
+			$translate = LiteralField::create('NoMultiple', '');
 		}
 		if($enabled) {
 			Translatable::enable_locale_filter();


### PR DESCRIPTION
in silverstripe-newsmodule/code/objects/News.php on line 214

Got an error when translatable is not installed.
