### PR TITLE
Null checking

### DIFF
--- a/code/pages/NewsHolderPage.php
+++ b/code/pages/NewsHolderPage.php
@@ -347,11 +347,17 @@ class NewsHolderPage_Controller extends Page_Controller
 			switch ($mapping[$action]) {
 				case 'show' :
 					$news = $this->getNews();
-					$this->Title = $news->Title . ' - ' . $this->Title;
+					if (isset($news))
+					{
+						$this->Title = $news->Title . ' - ' . $this->Title;
+					}
 					break;
 				case 'tag' :
 					$tags = $this->getTag();
-					$this->Title = $tags->Title . ' - ' . $this->Title;
+					if (isset($tags))
+					{
+						$this->Title = $tags->Title . ' - ' . $this->Title;	
+					}
 					break;
 				case 'tags' :
 					$this->Title = _t('News.ALLTAGS_PAGE', 'All tags - ') . $this->Title;

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -74,7 +74,7 @@ en:
     PUSHLIVE: Published
     PublishPermissionFailure: 'No permission to publish or unpublish news item'
     RSSFEED: 'News feed'
-    SINGULARNAME: Nieuwsbericht
+    SINGULARNAME: News
     SLIDE: Slideshow
     STATUS: Status
     SUMMARY: Summary/Abstract


### PR DESCRIPTION
I found that this was necessary to prevent my website from throwing errors if I navigated to a blog post that had not been published or did not exist. There's another fix that I am going to copy in as well, but you can decide whether or not it's worthwhile.