### PR TITLE
Author URLSegment not updated

### DIFF
--- a/code/objects/helpers/AuthorHelper.php
+++ b/code/objects/helpers/AuthorHelper.php
@@ -33,7 +33,7 @@ class AuthorHelper extends DataObject
 			}
 		}
 		$this->OriginalName = implode(' ', $nameParts);
-		if (!$this->URLSegment && !AuthorHelper::get()->filter(array('OriginalName' => $this->OriginalName))) {
+		if (!$this->URLSegment && !AuthorHelper::get()->filter(array('OriginalName' => $this->OriginalName))->Count()) {
 			$this->URLSegment = singleton('SiteTree')->generateURLSegment($this->OriginalName);
 		}
 	}


### PR DESCRIPTION
The Auhtor URLSegment field is not updated during onBeforeWrite.
The test failed on the value returned by `AuthorHelper::get()->filter(array('OriginalName' => $this->OriginalName))`.
Changing it by `AuthorHelper::get()->filter(array('OriginalName' => $this->OriginalName))->Count()` solved the probem.