### PR TITLE
Cannot save news with Silverstripe 3.2

### DIFF
--- a/code/objects/News.php
+++ b/code/objects/News.php
@@ -334,7 +334,7 @@ class News extends DataObject implements PermissionProvider
 		}
 		$this->Author = implode(' ', $nameParts);
 		$author = AuthorHelper::get()->filter('OriginalName', trim($this->Author))->first();
-		if (!$author->exists()) {
+		if (!$author) {
 			$author = AuthorHelper::create();
 			$author->OriginalName = trim($this->Author);
 			$author->write();

--- a/code/objects/News.php
+++ b/code/objects/News.php
@@ -333,11 +333,13 @@ class News extends DataObject implements PermissionProvider
 			}
 		}
 		$this->Author = implode(' ', $nameParts);
-		$author = AuthorHelper::get()->filter('OriginalName', trim($this->Author))->first();
-		if (!$author) {
+		$author = AuthorHelper::get()->filter('OriginalName', trim($this->Author));
+		if (!$author->Count()) {
 			$author = AuthorHelper::create();
 			$author->OriginalName = trim($this->Author);
 			$author->write();
+		} else {
+			$author = $author->first();
 		}
 		$this->AuthorHelperID = $author->ID;
 	}


### PR DESCRIPTION
With Silverstripe 3.2, I've get this error when saving a news: 
`Call to a member function exists() on null in /home/yves/www/ssdemo32/silverstripe-newsmodule/code/objects/News.php on line 338`

Changing `!$author->exists()` for `!$author` solve the problem.